### PR TITLE
Add missing Emacs version dependency

### DIFF
--- a/form-feed.el
+++ b/form-feed.el
@@ -4,6 +4,7 @@
 
 ;; Author: Vasilij Schneidermann <v.schneidermann@gmail.com>
 ;; URL: https://github.com/wasamasa/form-feed
+;; Package-Requires: ((emacs "24.3"))
 ;; Keywords: faces
 ;; Version: 0.1
 


### PR DESCRIPTION
You're using `setq-local`, so you either need to merge this commit, or if you'd rather preserve backwards-compatibility, switch to the old-school `(set (make-local-variable 'var) val)` pattern.
