### PR TITLE
Small fixes, and make lines clickable to hide/show sections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,10 @@ Enable the minor mode manually with ``M-x form-feed`` or in a hook:
 
     (add-hook 'emacs-lisp-mode-hook 'form-feed-mode)
 
+The lines are clickable, and hide/show following sections of code when
+clicked. When hidden, comments just after the form-feed are shown as a
+header.
+
 Internals
 ---------
 

--- a/form-feed.el
+++ b/form-feed.el
@@ -33,6 +33,9 @@
 ;; it for Emacs Lisp files for instance:
 ;;
 ;;     (add-hook 'emacs-lisp-mode-hook 'form-feed-mode)
+;;
+;; Clicking the horizontal lines will hide/show following sections of
+;; code. Comments just after the form-feed function as headers.
 
 ;; See the README for more info:
 ;; https://github.com/wasamasa/form-feed
@@ -59,17 +62,134 @@
   :type 'boolean
   :group 'form-feed)
 
+(defvar form-feed--keymap
+  (let ((k (make-sparse-keymap)))
+    (define-key k (kbd "<mouse-1>") #'form-feed-toggle-hiding)
+    (define-key k (kbd "<tab>") #'form-feed-toggle-hiding)
+    k))
+
 (defvar form-feed--font-lock-face
   ;; NOTE see (info "(elisp) Search-based fontification") and the
   ;; `(MATCHER . FACESPEC)' section for an explanation of the syntax
   `(face form-feed-line display (space . (:width text))
-         ,@(when form-feed-kick-cursor '(point-entered form-feed--kick-cursor))))
+         ,@(when form-feed-kick-cursor '(point-entered form-feed--kick-cursor))
+         keymap ,form-feed--keymap
+         pointer hand))
 
 (defvar form-feed--font-lock-keywords
   `((,page-delimiter 0 form-feed--font-lock-face t)))
 
 
-;; Definitions
+;; Hiding and showing form-feed-delimited sections of code.
+
+(defun form-feed-show-all ()
+  "Show all form-feed-delimited code sections."
+  (interactive)
+  (remove-overlays (point-min) (point-max) 'category 'form-feed--hs)
+  (remove-overlays (point-min) (point-max) 'category 'form-feed--hs-interior))
+
+(defun form-feed-hide-all ()
+  "Hide all form-feed-delimited code sections."
+  (interactive)
+  (let ((old-point (point)) next)
+    (form-feed-show-all)
+    (save-excursion
+      (save-match-data
+        (goto-char (point-min))
+        (while (search-forward-regexp page-delimiter nil t)
+          (setq next (save-excursion
+                       (when (search-forward-regexp
+                              (concat "\\'\\|" page-delimiter) nil t)
+                         (point))))
+          (unless (and next (<= (point) old-point) (<= old-point next))
+            (form-feed-hide)))))))
+
+(defun form-feed-toggle-hiding ()
+  "Toggle hiding the form-feed section surrounding point."
+  (interactive)
+  (if (get-char-property (point) 'form-feed--hidden)
+      (form-feed-show)
+    (form-feed-hide)))
+
+(defun form-feed-show (&rest _args)
+  "Show a hidden form-feed section at point.
+
+_ARGS are ignored."
+  (interactive)
+  ;; Find all top-level overlays; they contain pointers to invisible
+  ;; interior overlays.
+  (save-excursion
+    (mapcar
+     (lambda (o)
+       (when (eq (overlay-get o 'category) 'form-feed--hs)
+         (let ((o-int (overlay-get o 'form-feed--hs-interior)))
+           (when o-int (delete-overlay o-int))
+           (delete-overlay o))))
+     (overlays-at (point)))))
+
+(defun form-feed--overlay-modification (o _before _start _end _length)
+  (let ((o-int (overlay-get o 'form-feed--hs-interior)))
+    (delete-overlay o-int))
+  (delete-overlay o))
+
+;; Default properties of overlays.
+(put 'form-feed--hs 'evaporate t)
+(put 'form-feed--hs 'form-feed--hidden t)
+;; Any modification should show the overlays.
+(put 'form-feed--hs 'insert-in-front-hooks #'form-feed--overlay-modification)
+(put 'form-feed--hs 'insert-behind-hooks #'form-feed--overlay-modification)
+(put 'form-feed--hs 'modification-hooks #'form-feed--overlay-modification)
+
+(put 'form-feed--hs-interior 'evaporate t)
+;; The invisible property is a symbol that specifies who made it
+;; invisible. See also Info node (elisp)Invisible Text.
+(put 'form-feed--hs-interior 'invisible 'form-feed)
+(put 'form-feed--hs-interior 'isearch-open-invisible #'form-feed-show)
+(put 'form-feed--hs-interior 'isearch-open-invisible-temporary
+     (lambda (o invisible) (overlay-put o 'invisible (and invisible 'form-feed))))
+
+(defun form-feed-hide ()
+  "Hide a form-feed section surrounding point."
+  (interactive)
+  ;; The comment directly below the form-feed will be shown,
+  ;; everything else will become invisible
+  (let* ((start
+          (save-excursion
+            (when (looking-at-p page-delimiter) (forward-line))
+            (search-backward-regexp page-delimiter nil t)
+            (point)))
+         (start-int
+          (save-excursion (goto-char start)
+                          (while (and (= 0 (forward-line))
+                                    (looking-at-p comment-start)))
+                          (point)))
+         (end
+          (save-excursion
+            (goto-char start-int)
+            (search-forward-regexp (concat "\\'\\|" page-delimiter) nil t)
+            (unless (eobp)
+              (forward-char -1)
+              (when (bolp) (forward-char -1)))
+            (point)))
+         o-top o-int)
+    (when (and start start-int end)
+      (remove-overlays start end 'category 'form-feed--hs)
+      (remove-overlays start end 'category 'form-feed--hs-interior)
+      (setq o-top (make-overlay start end)
+            o-int (make-overlay start-int end))
+      (overlay-put o-top 'category 'form-feed--hs)
+      (overlay-put o-top 'form-feed--hs-interior o-int)
+      (overlay-put o-int 'category 'form-feed--hs-interior)
+      ;; (let ((num-lines-hidden
+      ;;        (when (< (- end start) 100000)
+      ;;          (format "[%d lines]"
+      ;;                  (- (line-number-at-pos end)
+      ;;                     (line-number-at-pos start-int))))))
+      ;;   (overlay-put o-int 'before-string num-lines-hidden))
+      )))
+
+
+;; Font-lock definitions
 
 (defun form-feed--kick-cursor (old new)
   ;; Don't do anything inside lisp code, because lisp code uses point
@@ -114,12 +234,20 @@ window.  It is suitable for inclusion into mode hooks and is
 intended to be used that way.  The following snippet would enable
 it for Emacs Lisp files for instance:
 
-    (add-hook 'emacs-lisp-mode-hook 'form-feed-mode)"
+    (add-hook 'emacs-lisp-mode-hook 'form-feed-mode)
+
+Clicking the horizontal lines will hide/show following sections of
+code. Comments just after the form-feed function as headers."
   :lighter " ^L"
-  (if form-feed-mode
-      (form-feed--add-font-lock-keywords)
-    (form-feed--remove-font-lock-keywords)))
+  (let ((invisibility '(form-feed . t)))
+    (cond
+     (form-feed-mode
+      (add-to-invisibility-spec invisibility)
+      (form-feed--add-font-lock-keywords))
+     (t
+      (form-feed-show-all)
+      (remove-from-invisibility-spec invisibility)
+      (form-feed--remove-font-lock-keywords)))))
 
 (provide 'form-feed)
-
 ;;; form-feed.el ends here


### PR DESCRIPTION
Hello, and thank you for writing this.

I found some minor issues (warnings about font-lock-fontify-buffer, which should be replaced with font-lock-flush/ensure in later emacs versions, also the convention is to use "--" to identify internal variables/functions).

I also wanted to make the lines clickable, so that they would hide/show the sections of code separated by form-feeds. This is consistent with what I've seen in how most emacs packages use form-feeds: they logically separate sections of code.

There is one serious bug that I found: enable form-feed-mode, modify buffer, save buffer. The newlines right after the form-feeds will be gone, which is a corruption of the file. I had to turn off the cursor-moving function to fix this (see the commit), maybe there's a better way of doing it. Changing file contents with a "visual" minor mode is "not good".

What do you think?
