### PR TITLE
Add instructions for installation via GNU Guix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,9 @@ Install from `Marmalade <https://marmalade-repo.org/>`_ or `MELPA
 (stable) <http://melpa.org/>`_ with ``M-x package-install RET
 form-feed RET``.
 
+``form-feed`` is also available as a recipe in `GNU Guix <https://guix.gnu.org/>`_.
+Install with ``guix install emacs-form-feed``.
+
 Usage
 -----
 


### PR DESCRIPTION
The recipe was added in https://git.savannah.gnu.org/cgit/guix.git/commit/?id=a24744bd0a9860c5233483e91c8ddb430311f9b7.